### PR TITLE
Upgrade ActiveRecord to 8.1 and bump version to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Command Line Tool for PostfixAdmin
 
 ## Requirements
 
-* Ruby 3.2 - 3.4
+* Ruby 3.2 or newer
 * MySQL/MariaDB
 * Dovecot (required for setting passwords using the `doveadm pw` subcommand)
 
 ## Version Notes
 
+* Version 0.8.x: Based on Active Record 8.1
 * Version 0.7.x: Based on Active Record 8.0
 * Version 0.6.x: Based on Active Record 7.2
 * Version 0.5.x: Based on Active Record 7.1

--- a/lib/postfix_admin/version.rb
+++ b/lib/postfix_admin/version.rb
@@ -1,3 +1,3 @@
 module PostfixAdmin
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/postfix_admin.gemspec
+++ b/postfix_admin.gemspec
@@ -10,12 +10,12 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Command Line Tool for PostfixAdmin}
   gem.homepage      = "https://github.com/krhitoshi/postfix_admin"
 
-  gem.required_ruby_version = ">= 2.7.0", "< 3.5"
+  gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "thor", "~> 1.3.1"
+  gem.add_dependency "thor", "~> 1.4.0"
   gem.add_dependency "activerecord", "~> 8.1.0"
   gem.add_dependency "mysql2", "~> 0.5"
-  gem.add_dependency "terminal-table", "~> 3.0.2"
+  gem.add_dependency "terminal-table", "~> 4.0.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "factory_bot", "~> 6.3.0"
   gem.add_development_dependency "rake", "~> 13.2.1"

--- a/postfix_admin.gemspec
+++ b/postfix_admin.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7.0", "< 3.5"
 
   gem.add_dependency "thor", "~> 1.3.1"
-  gem.add_dependency "activerecord", "~> 8.0.0"
+  gem.add_dependency "activerecord", "~> 8.1.0"
   gem.add_dependency "mysql2", "~> 0.5"
   gem.add_dependency "terminal-table", "~> 3.0.2"
   gem.add_development_dependency "pry"


### PR DESCRIPTION
## Summary

This PR upgrades ActiveRecord from 8.0 to 8.1 and bumps the version to 0.8.0.

## Changes

- **ActiveRecord**: Upgrade from `~> 8.0.0` to `~> 8.1.0` (8.1 series only)
- **Ruby version requirement**: Update from `>= 2.7.0, < 3.5` to `>= 3.2`
  - Rails 8.1 requires Ruby 3.2.0 or newer (same as Rails 8.0)
  - Update README to reflect "Ruby 3.2 or newer"
  - Simplify gemspec requirement to `>= 3.2`
- **Dependencies**:
  - Update thor from `~> 1.3.1` to `~> 1.4.0`
  - Update terminal-table from `~> 3.0.2` to `~> 4.0.0`
- **Version**: Bump to 0.8.0
- **README**: Add version 0.8.x note indicating Active Record 8.1 base

## Technical Details

- The dependency is pinned to `~> 8.1.0` to use only the 8.1 series
- This installs the latest ActiveRecord 8.1.x release
- Rails 8.1 is the latest stable release with ongoing support
- Ruby 3.2 is the minimum required version for Rails 8.1

## Test Plan

- CI will verify compatibility with Ruby 3.2, 3.3, 3.4
- All existing tests should pass with ActiveRecord 8.1
- Verify bundle install completes successfully with ActiveRecord 8.1.x
- Docker build should succeed with Ruby 3.2 base image